### PR TITLE
Fix og:image url is not valid

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -44,7 +44,10 @@ function MyApp({ Component, pageProps }) {
         <meta property="og:url" content="https://www.neovimconf.live" />
         <meta property="og:title" content="NeovimConf 2022" />
         <meta property="og:site_name" content="NeovimConf" />
-        <meta property="og:image" content="/neovimconf.png" />
+        <meta
+          property="og:image"
+          content="https://www.neovimconf.live/neovimconf.png"
+        />
         <meta property="og:image:width" content="1080" />
         <meta property="og:image:width" content="566" />
         <meta


### PR DESCRIPTION
Provided og:image URL, /neovimconf.png was not a valid URL.
